### PR TITLE
Update Converter.php

### DIFF
--- a/src/GreenCape/XML/Converter.php
+++ b/src/GreenCape/XML/Converter.php
@@ -85,7 +85,7 @@ class Converter implements \Iterator, \ArrayAccess
      */
     private function isFile($data): bool
     {
-        return file_exists($data);
+        return strlen($data) <= PHP_MAXPATHLEN && file_exists($data);
     }
 
     /**


### PR DESCRIPTION
Fixes "File name is longer than the maximum allowed path length on this platform" warning. Alternatively, `strpos($data, '<') === false` could be considered.